### PR TITLE
Fix STL verification step to match output filename

### DIFF
--- a/.github/workflows/build-stl.yml
+++ b/.github/workflows/build-stl.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Verify STL files were created
       run: |
         ls -la models/
-        file models/output.stl
+        file models/devo-energy-dome-45-adapter.stl
         
     - name: Upload STL artifacts
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to verify the correct STL output filename (`models/devo-energy-dome-45-adapter.stl`) instead of `models/output.stl`.

Closes #4.