### PR TITLE
Move contents: write permission to commit step only

### DIFF
--- a/.github/workflows/build-stl.yml
+++ b/.github/workflows/build-stl.yml
@@ -13,8 +13,6 @@ on:
 jobs:
   build-stl:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     
     steps:
     - name: Checkout repository
@@ -67,3 +65,5 @@ jobs:
           Co-Authored-By: GitHub Actions <action@github.com>"
           git push
         fi
+      permissions:
+        contents: write


### PR DESCRIPTION
This PR restricts the `contents: write` permission in the workflow to only the commit step, following the principle of least privilege.

Fixes #6.