### PR TITLE
Support multiple .scad files in STL generation

### DIFF
--- a/.github/workflows/build-stl.yml
+++ b/.github/workflows/build-stl.yml
@@ -34,13 +34,16 @@ jobs:
         # Create output directory if it doesn't exist
         mkdir -p models
         
-        # Generate main STL file
-        openscad -o models/devo-energy-dome-45-adapter.stl src/devo-energy-dome-45-adapter.scad
+        # Generate STL files for all .scad files in src/
+        for scad in src/*.scad; do
+          base=$(basename "$scad" .scad)
+          openscad -o "models/$base.stl" "$scad"
+        done
         
     - name: Verify STL files were created
       run: |
         ls -la models/
-        file models/devo-energy-dome-45-adapter.stl
+        file models/*.stl
         
     - name: Upload STL artifacts
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
This PR updates the workflow to automatically generate STL files for all `.scad` files in the `src/` directory, so new models are included without needing to update the workflow.

Closes #5.